### PR TITLE
feat(worker): implement structured thread concurrency model with roles

### DIFF
--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -190,7 +190,7 @@ func (crpc *CoordinatorRPC) Connect(args ConnectArgs, reply *ConnectReply) error
 	}
 
 	// reply
-	reply.WorkerID = resp.id
+	reply.Profile.ID = resp.id
 
 	log.Printf("<INFO> Worker %d is initialized\n", resp.id)
 

--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -24,7 +24,7 @@ type ConnectArgs struct{}
 
 // ConnectReply is an return type of RPC method "CoordinatorRPC.Connect"
 type ConnectReply struct {
-	WorkerID int
+	Profile WorkerProfile
 }
 
 // ScheduleArgs is an argument type of RPC method "CoordinatorRPC.Connect"
@@ -34,7 +34,7 @@ type ScheduleArgs struct {
 
 // ScheduleReply is an return type of RPC method "CoordinatorRPC.Connect"
 type ScheduleReply struct {
-	ScheduledTask Job
+	Task Job
 }
 
 func CoordinatorSock() string {


### PR DESCRIPTION
Introduces a structured concurrency model based on four distinct thread roles
 to manage access to shared state and isolate responsibilities.
 All operations on the shared state are sequentialized through
 the state manager thread, ensuring thread safety.
 Other threads operate independently and synchronize
  with the shared state solely via the state manager.

State manager thread: Ensures thread safety around all shared worker state and broadcasts state changes to other threads.

Execution loop thread: Drives the core MapReduce logic and is responsible for outgoing RPC calls.

Signal handler thread: Manages communication and heartbeats with the coordinator.

Shuffle server thread: Serves completed map outputs to reducer tasks.

Implements a two-stage graceful termination protocol to synchronize all threads:

Stage 1: Synchronization between the main thread and the state manager thread.

Stage 2: Synchronization between the state manager thread and
 the execution loop, signal handler, and shuffle server threads.

Refs #6